### PR TITLE
PAYLAPMEXT-166, PAYLAPMEXT-167, PAYLAPMEXT-168 + Sonar

### DIFF
--- a/src/main/java/com/payline/payment/slimpay/service/DefaultPaymentFormConfigurationService.java
+++ b/src/main/java/com/payline/payment/slimpay/service/DefaultPaymentFormConfigurationService.java
@@ -1,8 +1,7 @@
 package com.payline.payment.slimpay.service;
 
-
 import com.payline.payment.slimpay.utils.i18n.I18nService;
-import com.payline.payment.slimpay.utils.properties.service.LogoPropertiesEnum;
+import com.payline.payment.slimpay.utils.properties.service.LogoProperties;
 import com.payline.pmapi.bean.paymentform.bean.PaymentFormLogo;
 import com.payline.pmapi.bean.paymentform.request.PaymentFormLogoRequest;
 import com.payline.pmapi.bean.paymentform.response.logo.PaymentFormLogoResponse;
@@ -20,29 +19,28 @@ import java.util.Locale;
 
 import static com.payline.payment.slimpay.utils.properties.constants.LogoConstants.*;
 
+public abstract class DefaultPaymentFormConfigurationService implements PaymentFormConfigurationService {
 
-public interface DefaultPaymentFormConfigurationService extends PaymentFormConfigurationService {
-
-    Logger LOGGER = LogManager.getLogger(DefaultPaymentFormConfigurationService.class);
-    I18nService i18n = I18nService.getInstance();
+    private static final Logger LOGGER = LogManager.getLogger(DefaultPaymentFormConfigurationService.class);
+    private static final I18nService i18n = I18nService.getInstance();
 
     @Override
-    default PaymentFormLogoResponse getPaymentFormLogo(PaymentFormLogoRequest paymentFormLogoRequest) {
+    public PaymentFormLogoResponse getPaymentFormLogo(PaymentFormLogoRequest paymentFormLogoRequest) {
 
         Locale locale = paymentFormLogoRequest.getLocale();
 
         return PaymentFormLogoResponseFile.PaymentFormLogoResponseFileBuilder.aPaymentFormLogoResponseFile()
-                .withHeight(Integer.valueOf(LogoPropertiesEnum.INSTANCE.get(LOGO_HEIGHT)))
-                .withWidth(Integer.valueOf(LogoPropertiesEnum.INSTANCE.get(LOGO_WIDTH)))
-                .withTitle(i18n.getMessage(LogoPropertiesEnum.INSTANCE.get(LOGO_TITLE), locale))
-                .withAlt(i18n.getMessage(LogoPropertiesEnum.INSTANCE.get(LOGO_ALT), locale))
+                .withHeight(Integer.valueOf(LogoProperties.INSTANCE.get(LOGO_HEIGHT)))
+                .withWidth(Integer.valueOf(LogoProperties.INSTANCE.get(LOGO_WIDTH)))
+                .withTitle(i18n.getMessage(LogoProperties.INSTANCE.get(LOGO_TITLE), locale))
+                .withAlt(i18n.getMessage(LogoProperties.INSTANCE.get(LOGO_ALT), locale))
                 .build();
     }
 
     @Override
-    default PaymentFormLogo getLogo(String s, Locale locale) {
+    public PaymentFormLogo getLogo(String s, Locale locale) {
 
-        String fileName = LogoPropertiesEnum.INSTANCE.get(LOGO_FILE_NAME);
+        String fileName = LogoProperties.INSTANCE.get(LOGO_FILE_NAME);
         InputStream input = DefaultPaymentFormConfigurationService.class.getClassLoader().getResourceAsStream(fileName);
         if (input == null) {
             LOGGER.error("Unable to load the logo {}", LOGO_FILE_NAME);
@@ -54,11 +52,11 @@ public interface DefaultPaymentFormConfigurationService extends PaymentFormConfi
 
             // Recover byte array from image
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            ImageIO.write(logo, LogoPropertiesEnum.INSTANCE.get(LOGO_FORMAT), baos);
+            ImageIO.write(logo, LogoProperties.INSTANCE.get(LOGO_FORMAT), baos);
 
             return PaymentFormLogo.PaymentFormLogoBuilder.aPaymentFormLogo()
                     .withFile(baos.toByteArray())
-                    .withContentType(LogoPropertiesEnum.INSTANCE.get(LOGO_CONTENT_TYPE))
+                    .withContentType(LogoProperties.INSTANCE.get(LOGO_CONTENT_TYPE))
                     .build();
         } catch (IOException e) {
             LOGGER.error("Unable to load the logo", e);

--- a/src/main/java/com/payline/payment/slimpay/service/impl/BeanAssemblerServiceImpl.java
+++ b/src/main/java/com/payline/payment/slimpay/service/impl/BeanAssemblerServiceImpl.java
@@ -209,7 +209,12 @@ public class BeanAssemblerServiceImpl implements BeanAssemblerService {
         }
 
         final Buyer.FullName fullName = buyer.getFullName();
-        String internationalCellularPhoneNumber = PluginUtils.convertToInternational( buyer.getPhoneNumbers().get(Buyer.PhoneNumberType.CELLULAR), paymentRequest.getLocale() );
+
+        String internationalCellularPhoneNumber = null;
+        String cellularBuyer = buyer.getPhoneNumbers().get(Buyer.PhoneNumberType.CELLULAR);
+        if( cellularBuyer != null ){
+            internationalCellularPhoneNumber = PluginUtils.convertToInternational( cellularBuyer, paymentRequest.getLocale() );
+        }
 
         return Signatory.Builder.aSignatoryBuilder()
                 .withfamilyName(fullName == null ? null : fullName.getLastName())

--- a/src/main/java/com/payline/payment/slimpay/service/impl/BeanAssemblerServiceImpl.java
+++ b/src/main/java/com/payline/payment/slimpay/service/impl/BeanAssemblerServiceImpl.java
@@ -47,7 +47,7 @@ public class BeanAssemblerServiceImpl implements BeanAssemblerService {
     private static final String FOO = "foo";
     private static final String PONCTUEL = "OOFF";
     private static final String EMPTY_REQUEST_ERROR_MESSAGE = "PaymentRequest is null or empty";
-    private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+    private static final String DATE_FORMAT_ISO = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
 
     /**
@@ -79,13 +79,17 @@ public class BeanAssemblerServiceImpl implements BeanAssemblerService {
 
         Payment.Builder paymentBuilder = Payment.Builder.aPaymentBuilder()
                 .withReference(paymentRequest.getTransactionId())
-                .withExecutionDate( new SimpleDateFormat(DATE_FORMAT).format( paymentRequest.getDifferedActionDate()))
                 .withScheme(requestConfigService.getParameterValue(paymentRequest, FIRST_PAYMENT_SCHEME))
                 .withDirection(Direction.IN.name())
                 .withAction(CREATE)
                 .withAmount(createStringAmount(paymentRequest.getAmount()))
                 .withCurrency(getCurrencyAsString(paymentRequest.getAmount()))
                 .withLabel(paymentRequest.getSoftDescriptor());
+
+        if( paymentRequest.getDifferedActionDate() != null ){
+            paymentBuilder.withExecutionDate( new SimpleDateFormat(DATE_FORMAT_ISO).format( paymentRequest.getDifferedActionDate()) );
+        }
+
         return paymentBuilder.build();
     }
 

--- a/src/main/java/com/payline/payment/slimpay/service/impl/ConfigurationServiceImpl.java
+++ b/src/main/java/com/payline/payment/slimpay/service/impl/ConfigurationServiceImpl.java
@@ -6,7 +6,7 @@ import com.payline.payment.slimpay.utils.PluginUtils;
 import com.payline.payment.slimpay.utils.http.SlimpayHttpClient;
 import com.payline.payment.slimpay.utils.i18n.I18nService;
 import com.payline.payment.slimpay.utils.properties.constants.ConfigurationConstants;
-import com.payline.payment.slimpay.utils.properties.service.ReleasePropertiesEnum;
+import com.payline.payment.slimpay.utils.properties.service.ReleaseProperties;
 import com.payline.pmapi.bean.configuration.ReleaseInformation;
 import com.payline.pmapi.bean.configuration.parameter.AbstractParameter;
 import com.payline.pmapi.bean.configuration.parameter.impl.InputParameter;
@@ -178,11 +178,11 @@ public class ConfigurationServiceImpl implements ConfigurationService {
     @Override
     public ReleaseInformation getReleaseInformation() {
 
-        LocalDate date = LocalDate.parse(ReleasePropertiesEnum.INSTANCE.get(ConfigurationConstants.RELEASE_DATE),
+        LocalDate date = LocalDate.parse(ReleaseProperties.INSTANCE.get(ConfigurationConstants.RELEASE_DATE),
                 DateTimeFormatter.ofPattern(ConfigurationConstants.RELEASE_DATE_FORMAT));
         return ReleaseInformation.ReleaseBuilder.aRelease()
                 .withDate(date)
-                .withVersion(ReleasePropertiesEnum.INSTANCE.get(ConfigurationConstants.RELEASE_VERSION))
+                .withVersion(ReleaseProperties.INSTANCE.get(ConfigurationConstants.RELEASE_VERSION))
                 .build();
     }
 

--- a/src/main/java/com/payline/payment/slimpay/service/impl/PaymentFormConfigurationServiceImpl.java
+++ b/src/main/java/com/payline/payment/slimpay/service/impl/PaymentFormConfigurationServiceImpl.java
@@ -13,15 +13,13 @@ import java.util.Locale;
 /**
  * Created on 27/08/2018.
  */
-public class PaymentFormConfigurationServiceImpl implements DefaultPaymentFormConfigurationService {
-
+public class PaymentFormConfigurationServiceImpl extends DefaultPaymentFormConfigurationService {
 
     private I18nService i18n;
 
     public PaymentFormConfigurationServiceImpl() {
         i18n = I18nService.getInstance();
     }
-
 
     @Override
     public PaymentFormConfigurationResponse getPaymentFormConfiguration(PaymentFormConfigurationRequest request) {

--- a/src/main/java/com/payline/payment/slimpay/service/impl/PaymentWithRedirectionServiceImpl.java
+++ b/src/main/java/com/payline/payment/slimpay/service/impl/PaymentWithRedirectionServiceImpl.java
@@ -183,7 +183,7 @@ public class PaymentWithRedirectionServiceImpl implements PaymentWithRedirection
                             .build();
                 // Payment not processed
                 case PaymentExecutionStatus.NOT_PROCESSED:
-                    LOGGER.error("Payment not processed");
+                    LOGGER.error(NOT_PROCESSED_PAYMENT);
                     return PaymentResponseFailure.PaymentResponseFailureBuilder
                             .aPaymentResponseFailure()
                             .withErrorCode(truncateError(NOT_PROCESSED_PAYMENT))

--- a/src/main/java/com/payline/payment/slimpay/utils/PluginUtils.java
+++ b/src/main/java/com/payline/payment/slimpay/utils/PluginUtils.java
@@ -123,7 +123,7 @@ public class PluginUtils {
                     phoneNumber = phonePrefix + phoneNumber;
                 }
             } catch( IllegalArgumentException e ){
-                LOGGER.warn("Cannot resolve a phone prefix", e);
+                LOGGER.warn("Cannot resolve a phone prefix");
             }
         }
         return phoneNumber;

--- a/src/main/java/com/payline/payment/slimpay/utils/http/SlimpayHttpClient.java
+++ b/src/main/java/com/payline/payment/slimpay/utils/http/SlimpayHttpClient.java
@@ -9,6 +9,7 @@ import com.payline.payment.slimpay.exception.InvalidDataException;
 import com.payline.payment.slimpay.exception.PluginTechnicalException;
 import com.payline.payment.slimpay.exception.SlimpayHttpException;
 import com.payline.payment.slimpay.utils.SlimpayConstants;
+import com.payline.payment.slimpay.utils.properties.service.ConfigProperties;
 import com.payline.pmapi.bean.configuration.PartnerConfiguration;
 import com.payline.pmapi.bean.payment.ContractConfiguration;
 import com.payline.pmapi.logger.LogManager;
@@ -28,7 +29,6 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.logging.log4j.Logger;
 
 import javax.net.ssl.HttpsURLConnection;
-import java.util.Currency;
 import java.util.List;
 
 public class SlimpayHttpClient {
@@ -53,6 +53,8 @@ public class SlimpayHttpClient {
     // Messages
     private static final String EMPTY_RESPONSE_MESSAGE = "response is empty";
     private static final String REL_NOT_FOUND_MESSAGE = "Rel not found";
+    private static final String PARTNER_CONFIGURATION_ERROR = "Partner configuration must not be null";
+    private static final String PARTNER_CONFIGURATION_FIELD = "request.partnerConfiguration";
 
     // URL parameters keys
     private static final String CREDITOR_REFERENCE = "creditorReference";
@@ -69,11 +71,14 @@ public class SlimpayHttpClient {
      * Instantiate a HTTP client with default values.
      */
     private SlimpayHttpClient() {
-        //Define Client builder used in every Request to Slimpay
+        int connectTimeout = Integer.parseInt(ConfigProperties.INSTANCE.get("http.connectTimeout"));
+        int requestTimeout = Integer.parseInt(ConfigProperties.INSTANCE.get("http.writeTimeout"));
+        int readTimeout = Integer.parseInt(ConfigProperties.INSTANCE.get("http.readTimeout"));
+
         final RequestConfig requestConfig = RequestConfig.custom()
-                .setConnectTimeout(2 * 1000)
-                .setConnectionRequestTimeout(3 * 1000)
-                .setSocketTimeout(4 * 1000).build();
+                .setConnectTimeout(connectTimeout * 1000)
+                .setConnectionRequestTimeout(requestTimeout * 1000)
+                .setSocketTimeout(readTimeout * 1000).build();
 
         httpClientBuilder = HttpClientBuilder.create();
         httpClientBuilder.useSystemProperties()
@@ -106,7 +111,7 @@ public class SlimpayHttpClient {
      */
     public SlimpayOrderResponse testConnection( PartnerConfiguration partnerConfiguration, JsonBody body) throws PluginTechnicalException {
         if( partnerConfiguration == null ){
-            throw new InvalidDataException("Partner configuration must not be null", "request.partnerConfiguration");
+            throw new InvalidDataException(PARTNER_CONFIGURATION_ERROR, PARTNER_CONFIGURATION_FIELD);
         }
         String ns = partnerConfiguration.getProperty( SlimpayConstants.API_NS_KEY );
         CustomRel rel = new CustomRel(ns + API_REL_CREATE_ORDER);
@@ -133,7 +138,7 @@ public class SlimpayHttpClient {
      */
     public SlimpayResponse createOrder( PartnerConfiguration partnerConfiguration, JsonBody body) throws PluginTechnicalException {
         if( partnerConfiguration == null ){
-            throw new InvalidDataException("Partner configuration must not be null", "request.partnerConfiguration");
+            throw new InvalidDataException(PARTNER_CONFIGURATION_ERROR, PARTNER_CONFIGURATION_FIELD);
         }
         String ns = partnerConfiguration.getProperty( SlimpayConstants.API_NS_KEY );
         CustomRel rel = new CustomRel(ns + API_REL_CREATE_ORDER);
@@ -178,7 +183,7 @@ public class SlimpayHttpClient {
      */
     public SlimpayResponse createPayout(PartnerConfiguration partnerConfiguration, JsonBody body) throws PluginTechnicalException {
         if( partnerConfiguration == null ){
-            throw new InvalidDataException("Partner configuration must not be null", "request.partnerConfiguration");
+            throw new InvalidDataException(PARTNER_CONFIGURATION_ERROR, PARTNER_CONFIGURATION_FIELD);
         }
         String ns = partnerConfiguration.getProperty( SlimpayConstants.API_NS_KEY );
         CustomRel rel = new CustomRel(ns + API_REL_CREATE_PAYOUT);
@@ -211,7 +216,7 @@ public class SlimpayHttpClient {
     public SlimpayResponse getOrder(PartnerConfiguration partnerConfiguration, ContractConfiguration contractConfiguration, String orderReference)
             throws PluginTechnicalException {
         if( partnerConfiguration == null ){
-            throw new InvalidDataException("Partner configuration must not be null", "request.partnerConfiguration");
+            throw new InvalidDataException(PARTNER_CONFIGURATION_ERROR, PARTNER_CONFIGURATION_FIELD);
         }
         if( contractConfiguration == null ){
             throw new InvalidDataException("Contract configuration must not be null", "request.contractConfiguration");
@@ -248,7 +253,7 @@ public class SlimpayHttpClient {
      */
     public SlimpayResponse getPayment(PartnerConfiguration partnerConfiguration, String paymentId) throws PluginTechnicalException {
         if( partnerConfiguration == null ){
-            throw new InvalidDataException("Partner configuration must not be null", "request.partnerConfiguration");
+            throw new InvalidDataException(PARTNER_CONFIGURATION_ERROR, PARTNER_CONFIGURATION_FIELD);
         }
         String ns = partnerConfiguration.getProperty( SlimpayConstants.API_NS_KEY );
         CustomRel rel = new CustomRel(ns + API_REL_GET_PAYMENT);
@@ -296,7 +301,7 @@ public class SlimpayHttpClient {
     public SlimpayResponse searchPayment(PartnerConfiguration partnerConfiguration, ContractConfiguration contractConfiguration,
                                          String paymentReference, String mandateReference, String subscriberReference ) throws PluginTechnicalException {
         if( partnerConfiguration == null ){
-            throw new InvalidDataException("Partner configuration must not be null", "request.partnerConfiguration");
+            throw new InvalidDataException(PARTNER_CONFIGURATION_ERROR, PARTNER_CONFIGURATION_FIELD);
         }
         if( contractConfiguration == null ){
             throw new InvalidDataException("Contract configuration must not be null", "request.contractConfiguration");
@@ -350,7 +355,7 @@ public class SlimpayHttpClient {
      */
     public String getPaymentRejectReason(PartnerConfiguration partnerConfiguration, String paymentId) throws PluginTechnicalException {
         if( partnerConfiguration == null ){
-            throw new InvalidDataException("Partner configuration must not be null", "request.partnerConfiguration");
+            throw new InvalidDataException(PARTNER_CONFIGURATION_ERROR, PARTNER_CONFIGURATION_FIELD);
         }
         String ns = partnerConfiguration.getProperty( SlimpayConstants.API_NS_KEY );
         CustomRel rel = new CustomRel(ns + API_REL_GET_PAYMENT_ISSUES);
@@ -400,7 +405,7 @@ public class SlimpayHttpClient {
      */
     public SlimpayResponse cancelPayment(PartnerConfiguration partnerConfiguration, String paymentId, JsonBody body) throws PluginTechnicalException {
         if( partnerConfiguration == null ){
-            throw new InvalidDataException("Partner configuration must not be null", "request.partnerConfiguration");
+            throw new InvalidDataException(PARTNER_CONFIGURATION_ERROR, PARTNER_CONFIGURATION_FIELD);
         }
         String ns = partnerConfiguration.getProperty( SlimpayConstants.API_NS_KEY );
         CustomRel relCancelPayment = new CustomRel(ns + API_REL_CANCEL_PAYMENT);

--- a/src/main/java/com/payline/payment/slimpay/utils/properties/service/ConfigProperties.java
+++ b/src/main/java/com/payline/payment/slimpay/utils/properties/service/ConfigProperties.java
@@ -1,20 +1,24 @@
 package com.payline.payment.slimpay.utils.properties.service;
 
+import com.payline.pmapi.logger.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.Properties;
 
 /**
  * Utility class which reads and provides config properties.
  */
-public enum ConfigPropertiesEnum implements PropertiesService {
+public enum ConfigProperties implements PropertiesService {
 
     INSTANCE;
 
     private static final String FILENAME = "config.properties";
+    private static final Logger LOGGER = LogManager.getLogger(ConfigProperties.class);
 
     private final Properties properties;
 
     /* This class has only static methods: no need to instantiate it */
-    ConfigPropertiesEnum() {
+    ConfigProperties() {
         properties = new Properties();
         // init of the Properties
         readProperties(properties);
@@ -29,6 +33,11 @@ public enum ConfigPropertiesEnum implements PropertiesService {
     @Override
     public Properties getProperties() {
         return properties;
+    }
+
+    @Override
+    public void logError(String message, Throwable t) {
+        LOGGER.error( message, t );
     }
 
 }

--- a/src/main/java/com/payline/payment/slimpay/utils/properties/service/LogoProperties.java
+++ b/src/main/java/com/payline/payment/slimpay/utils/properties/service/LogoProperties.java
@@ -1,22 +1,25 @@
 package com.payline.payment.slimpay.utils.properties.service;
 
 import com.payline.payment.slimpay.utils.properties.constants.LogoConstants;
+import com.payline.pmapi.logger.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Properties;
 
 /**
  * Utility class which reads and provides config properties.
  */
-public enum LogoPropertiesEnum implements PropertiesService {
+public enum LogoProperties implements PropertiesService {
 
     INSTANCE;
 
     private static final String FILENAME = LogoConstants.LOGO_PROPERTIES;
+    private static final Logger LOGGER = LogManager.getLogger(LogoProperties.class);
 
     private final Properties properties;
 
     /* This class has only static methods: no need to instantiate it */
-    LogoPropertiesEnum() {
+    LogoProperties() {
         properties = new Properties();
         // init of the Properties
         readProperties(properties);
@@ -31,6 +34,11 @@ public enum LogoPropertiesEnum implements PropertiesService {
     @Override
     public Properties getProperties() {
         return properties;
+    }
+
+    @Override
+    public void logError(String message, Throwable t) {
+        LOGGER.error( message, t );
     }
 
 }

--- a/src/main/java/com/payline/payment/slimpay/utils/properties/service/PropertiesService.java
+++ b/src/main/java/com/payline/payment/slimpay/utils/properties/service/PropertiesService.java
@@ -1,16 +1,10 @@
 package com.payline.payment.slimpay.utils.properties.service;
 
-import com.payline.pmapi.logger.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
 public interface PropertiesService {
-
-
-    Logger LOGGER = LogManager.getLogger(PropertiesService.class);
 
     /**
      * Get a config property by its name.
@@ -62,10 +56,12 @@ public interface PropertiesService {
             properties.load(inputStream);
 
         } catch (IOException e) {
-            LOGGER.error("Unable to load the file {}", fileName, e);
+            logError( "Unable to load the file " + fileName, e );
             throw new RuntimeException(e);
         }
 
     }
+
+    void logError( String message, Throwable t );
 
 }

--- a/src/main/java/com/payline/payment/slimpay/utils/properties/service/ReleaseProperties.java
+++ b/src/main/java/com/payline/payment/slimpay/utils/properties/service/ReleaseProperties.java
@@ -1,22 +1,25 @@
 package com.payline.payment.slimpay.utils.properties.service;
 
 import com.payline.payment.slimpay.utils.properties.constants.ConfigurationConstants;
+import com.payline.pmapi.logger.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Properties;
 
 /**
  * Utility class which reads and provides config properties.
  */
-public enum ReleasePropertiesEnum implements PropertiesService {
+public enum ReleaseProperties implements PropertiesService {
 
     INSTANCE;
 
     private static final String FILENAME = ConfigurationConstants.RELEASE_PROPERTIES;
+    private static final Logger LOGGER = LogManager.getLogger(ReleaseProperties.class);
 
     private final Properties properties;
 
     /* This class has only static methods: no need to instantiate it */
-    ReleasePropertiesEnum() {
+    ReleaseProperties() {
         properties = new Properties();
         // init of the Properties
         readProperties(properties);
@@ -31,6 +34,11 @@ public enum ReleasePropertiesEnum implements PropertiesService {
     @Override
     public Properties getProperties() {
         return properties;
+    }
+
+    @Override
+    public void logError(String message, Throwable t) {
+        LOGGER.error( message, t );
     }
 
 }

--- a/src/test/java/com/payline/payment/slimpay/bean/common/SlimPayOrderItemTest.java
+++ b/src/test/java/com/payline/payment/slimpay/bean/common/SlimPayOrderItemTest.java
@@ -10,18 +10,18 @@ import org.powermock.reflect.Whitebox;
 
 import static com.payline.payment.slimpay.utils.BeansUtils.createDefaultMandate;
 import static com.payline.payment.slimpay.utils.BeansUtils.createDefaultPayin;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 
 
 @PrepareForTest({SlimPayOrderItem.class})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SlimPayOrderItemTest {
 
-    SlimPayOrderItem orderItem;
     private Logger mockLogger;
 
     @BeforeEach
     public void setUp() {
-
         mockLogger = Mockito.mock(Logger.class);
 
         Whitebox.setInternalState(SlimPayOrderItem.class, "LOGGER", mockLogger);
@@ -29,37 +29,37 @@ public class SlimPayOrderItemTest {
 
     @Test
     public void SlimpayOrderItemOK(){
-        orderItem = SlimPayOrderItem.Builder.aSlimPayOrderItemBuilder()
+        SlimPayOrderItem.Builder.aSlimPayOrderItemBuilder()
                 .withType("payment")
                 .withPayin(createDefaultPayin("reference payment"))
                 .build();
 
-
+        Mockito.verify(mockLogger, never()).warn(anyString());
     }
 
     @Test
     public void SlimpayOrderItemMandateOK(){
-        orderItem = SlimPayOrderItem.Builder.aSlimPayOrderItemBuilder()
+        SlimPayOrderItem.Builder.aSlimPayOrderItemBuilder()
                 .withType("signMandate")
                 .withMandate(createDefaultMandate("reference mandate"))
                 .build();
 
+        Mockito.verify(mockLogger, never()).warn(anyString());
     }
 
     @Test
     public void SlimpayOrderItemMandateWithoutReference(){
-        orderItem = SlimPayOrderItem.Builder.aSlimPayOrderItemBuilder()
+        SlimPayOrderItem.Builder.aSlimPayOrderItemBuilder()
                 .withType("signMandate")
                 .build();
-        Mockito.verify(mockLogger, Mockito.times(1)).warn(Mockito.eq(orderItem.MANDATE_WARN));
 
+        Mockito.verify(mockLogger, Mockito.times(1)).warn(Mockito.eq(SlimPayOrderItem.MANDATE_WARN));
     }
     @Test
     public void SlimpayOrderItemMandateWithoutType(){
-        orderItem = SlimPayOrderItem.Builder.aSlimPayOrderItemBuilder()
+        SlimPayOrderItem.Builder.aSlimPayOrderItemBuilder()
                 .build();
-        Mockito.verify(mockLogger, Mockito.times(1)).warn(Mockito.eq(orderItem.TYPE_WARN));
-        Mockito.verify(mockLogger, Mockito.times(1)).warn(Mockito.eq(orderItem.TYPE_WARN));
 
+        Mockito.verify(mockLogger, Mockito.times(1)).warn(Mockito.eq(SlimPayOrderItem.TYPE_WARN));
     }
 }

--- a/src/test/java/com/payline/payment/slimpay/utils/PluginUtilsTest.java
+++ b/src/test/java/com/payline/payment/slimpay/utils/PluginUtilsTest.java
@@ -67,68 +67,68 @@ public class PluginUtilsTest {
     }
 
     @Test
-    public void convertToE164_nothingToDo(){
+    public void convertToInternational_nothingToDo(){
         assertEquals( "+33601020304", PluginUtils.convertToInternational( "+33601020304", Locale.FRANCE ));
         assertEquals( "+331234", PluginUtils.convertToInternational( "+331234", Locale.FRANCE ));
     }
 
     @Test
-    public void convertToE164_removeDots(){
+    public void convertToInternational_removeDots(){
         assertEquals( "+33601020304", PluginUtils.convertToInternational( "+336.01.02.03.04", Locale.FRANCE ));
     }
 
     @Test
-    public void convertToE164_removeSpaces(){
+    public void convertToInternational_removeSpaces(){
         assertEquals( "+33601020304", PluginUtils.convertToInternational( "+336 01 02 03 04", Locale.FRANCE ));
     }
 
     @Test
-    public void convertToE164_removeDashes(){
+    public void convertToInternational_removeDashes(){
         assertEquals( "+33601020304", PluginUtils.convertToInternational( "+336-010-203-04", Locale.FRANCE ));
     }
 
     @Test
-    public void convertToE164_removeAll(){
+    public void convertToInternational_removeAll(){
         assertEquals( "+33601020304", PluginUtils.convertToInternational( "+336 010-203.04", Locale.FRANCE ));
     }
 
     @Test
-    public void convertToE164_addCountryCode_noCountryFr(){
+    public void convertToInternational_addCountryCode_noCountryFr(){
         assertEquals( "0601020304", PluginUtils.convertToInternational( "0601020304", Locale.FRENCH ));
     }
 
     @Test
-    public void convertToE164_addCountryCode_fr(){
+    public void convertToInternational_addCountryCode_fr(){
         assertEquals( "+33601020304", PluginUtils.convertToInternational( "0601020304", Locale.FRANCE ));
     }
 
     @Test
-    public void convertToE164_addCountryCode_be_fr(){
+    public void convertToInternational_addCountryCode_be_fr(){
         assertEquals( "+32451234567", PluginUtils.convertToInternational( "0451 23 45 67", new Locale("fr", "be") ));
     }
 
     @Test
-    public void convertToE164_addCountryCode_be_nl(){
+    public void convertToInternational_addCountryCode_be_nl(){
         assertEquals( "+32451234567", PluginUtils.convertToInternational( "0451 23 45 67", new Locale("nl", "be") ));
     }
 
     @Test
-    public void convertToE164_addCountryCode_nl(){
+    public void convertToInternational_addCountryCode_nl(){
         assertEquals( "+31123456789", PluginUtils.convertToInternational( "012 345 67 89", new Locale("nl", "nl") ));
     }
 
     @Test
-    public void convertToE164_addCountryCode_noCountryEn(){
+    public void convertToInternational_addCountryCode_noCountryEn(){
         assertEquals( "02041345678", PluginUtils.convertToInternational( "020 4134 5678", Locale.ENGLISH ));
     }
 
     @Test
-    public void convertToE164_addCountryCode_uk(){
+    public void convertToInternational_addCountryCode_uk(){
         assertEquals( "+442041345678", PluginUtils.convertToInternational( "020 4134 5678", Locale.UK ));
     }
 
     @Test
-    public void convertToE164_addCountryCode_us(){
+    public void convertToInternational_addCountryCode_us(){
         assertEquals( "+12135096995", PluginUtils.convertToInternational( "213-509-6995", Locale.US ));
     }
 

--- a/src/test/java/com/payline/payment/slimpay/utils/service/ConfigPropertiesTest.java
+++ b/src/test/java/com/payline/payment/slimpay/utils/service/ConfigPropertiesTest.java
@@ -1,16 +1,16 @@
 package com.payline.payment.slimpay.utils.service;
 
 import com.payline.payment.slimpay.utils.properties.constants.ConfigurationConstants;
-import com.payline.payment.slimpay.utils.properties.service.ConfigPropertiesEnum;
+import com.payline.payment.slimpay.utils.properties.service.ConfigProperties;
 import com.payline.payment.slimpay.utils.properties.service.PropertiesService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
-class ConfigPropertiesEnumTest {
+class ConfigPropertiesTest {
 
-    private PropertiesService service = ConfigPropertiesEnum.INSTANCE;
+    private PropertiesService service = ConfigProperties.INSTANCE;
 
     private String key;
 
@@ -31,14 +31,14 @@ class ConfigPropertiesEnumTest {
 
     @Test
     public void getFromKeyKO() {
-        key = ConfigPropertiesEnum.INSTANCE.get("BadKey");
+        key = ConfigProperties.INSTANCE.get("BadKey");
         Assertions.assertNull(key);
 
     }
 
     @Test
     public void getFromKeyOK() {
-        key = ConfigPropertiesEnum.INSTANCE.get("http.connectTimeout");
+        key = ConfigProperties.INSTANCE.get("http.connectTimeout");
         Assertions.assertNotNull(key);
     }
 

--- a/src/test/java/com/payline/payment/slimpay/utils/service/LogoPropertiesTest.java
+++ b/src/test/java/com/payline/payment/slimpay/utils/service/LogoPropertiesTest.java
@@ -1,16 +1,16 @@
 package com.payline.payment.slimpay.utils.service;
 
 import com.payline.payment.slimpay.utils.properties.constants.LogoConstants;
-import com.payline.payment.slimpay.utils.properties.service.LogoPropertiesEnum;
+import com.payline.payment.slimpay.utils.properties.service.LogoProperties;
 import com.payline.payment.slimpay.utils.properties.service.PropertiesService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
-class LogoPropertiesEnumTest {
+class LogoPropertiesTest {
 
-    private PropertiesService service = LogoPropertiesEnum.INSTANCE;
+    private PropertiesService service = LogoProperties.INSTANCE;
 
     @Test
     void getFilename() {

--- a/src/test/java/com/payline/payment/slimpay/utils/service/ReleasePropertiesTest.java
+++ b/src/test/java/com/payline/payment/slimpay/utils/service/ReleasePropertiesTest.java
@@ -2,15 +2,15 @@ package com.payline.payment.slimpay.utils.service;
 
 import com.payline.payment.slimpay.utils.properties.constants.ConfigurationConstants;
 import com.payline.payment.slimpay.utils.properties.service.PropertiesService;
-import com.payline.payment.slimpay.utils.properties.service.ReleasePropertiesEnum;
+import com.payline.payment.slimpay.utils.properties.service.ReleaseProperties;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
-class ReleasePropertiesEnumTest {
+class ReleasePropertiesTest {
 
-    private PropertiesService service = ReleasePropertiesEnum.INSTANCE;
+    private PropertiesService service = ReleaseProperties.INSTANCE;
 
     @Test
     void getFilename() {


### PR DESCRIPTION
PAYLAPMEXT-166: gestion du cas où `differedActionDate` n'est pas renseigné
PAYLAPMEXT-167: gestion du cas où le téléphone cellulaire du buyer n'est pas fourni
PAYLAPMEXT-168: suppression de l'exception dans les logs lorsque le code pays est absent
Qualimétrie: correction issues Sonar, retrait du suffixe `Enum` sur les singletons, utilisation du fichier config.properties pour les valeurs des timeout HTTP